### PR TITLE
Rework the release Action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: Build on push
 
 on:
   push:
@@ -20,32 +20,3 @@ jobs:
           java-version: '11'
       - name: Build
         run: mvn -DskipTests=false -Dsalesforce.jwt.rsa.private-key=${{ secrets.SALESFORCE_OAUTH_PRIVATE_KEY_BASE64 }} -Dsalesforce.jwt.rsa.public-key=${{ secrets.SALESFORCE_OAUTH_PUBLIC_KEY_BASE64 }} -Dsalesforce.jwt.rsa.password=${{ secrets.SALESFORCE_OAUTH_RSA_PASSWORD }} -Dsalesforce.api.client-id=${{ secrets.SALESFORCE_OAUTH_CLIENT_ID }} -Dsalesforce.api.client-secret=${{ secrets.SALESFORCE_OAUTH_CLIENT_SECRET }} -Dsalesforce.api-base-url=${{ secrets.SALESFORCE_BASE_URL }} -Dsalesforce.jwt.audience=${{ secrets.SALESFORCE_JWT_AUDIENCE }} -Dsalesforce.jwt.subject=${{ secrets.SALESFORCE_USERNAME }} verify
-
-  # Publish if a tag is on this commit
-  publish:
-    name: Publish to Maven Central
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish
-        run: mvn deploy
-      - name: Output tag to use in jobs below
-        run: echo "::set-output tag=$(git tag --points-at HEAD)"
-
-  # And then only make a Github Release if published successfully
-  create-release:
-    name: Create GitHub Release
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GITHUB_TOKEN is provided by default by Actions
-        with:
-          tag_name: ${{ steps.publish.outputs.tag }}
-          release_name: Release ${{ steps.publish.outputs.tag }}
-          body_path: CHANGELOG.md
-          draft: false
-          prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Publish to Sonatype
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: ${{ secrets.MAVEN_USERNAME }}
+          server-password: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      - name: Build and publish
+        run: |
+          mvn \
+            -Dsalesforce.api-base-url=${{ secrets.SALESFORCE_BASE_URL }} \
+            -Dsalesforce.api.client-id=${{ secrets.SALESFORCE_OAUTH_CLIENT_ID }} \
+            -Dsalesforce.api.client-secret=${{ secrets.SALESFORCE_OAUTH_CLIENT_SECRET }} \
+            -Dsalesforce.jwt.audience=${{ secrets.SALESFORCE_JWT_AUDIENCE }} \
+            -Dsalesforce.jwt.rsa.password=${{ secrets.SALESFORCE_OAUTH_RSA_PASSWORD }} \
+            -Dsalesforce.jwt.rsa.private-key=${{ secrets.SALESFORCE_OAUTH_PRIVATE_KEY_BASE64 }} \
+            -Dsalesforce.jwt.rsa.public-key=${{ secrets.SALESFORCE_OAUTH_PUBLIC_KEY_BASE64 }} \
+            -Dsalesforce.jwt.subject=${{ secrets.SALESFORCE_USERNAME }} \
+            -DskipTests=true \
+            --batch-mode \
+            release:prepare \
+            release:perform
+      - name: Output tag to use in jobs below
+        run: echo "::set-output tag=$(git tag --points-at HEAD)"
+
+  # And then only make a Github Release if published successfully
+  create-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GITHUB_TOKEN is provided by default by Actions
+        with:
+          tag_name: ${{ steps.publish.outputs.tag }}
+          release_name: Release ${{ steps.publish.outputs.tag }}
+          body_path: CHANGELOG.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
- Separate out the publishing part into `release.yaml`.
- Change to the maven release command. I'm including all the salesforce env vars, since I believe the maven release step will run the build as well. 
- Make it trigger `on.workflow_dispatch` ([announcement docs](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)).

I made a Sonatype account to try to test this myself, but I'm missing some part, because I'm not seeing where to add my GPG public key, so I don't think I'm even in the right place. All that to say, this is untested. :sweat_smile: 

Closes #3 